### PR TITLE
Energy Frequency Table

### DIFF
--- a/spotifyMini/Base.lproj/Main.storyboard
+++ b/spotifyMini/Base.lproj/Main.storyboard
@@ -199,10 +199,10 @@
                                                     <constraint firstItem="8po-IE-zp4" firstAttribute="top" secondItem="oDc-8S-AG0" secondAttribute="top" constant="8" id="D8B-T2-BzG"/>
                                                 </constraints>
                                             </view>
-                                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="o0v-WD-4GY" userLabel="line container 2">
+                                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="o0v-WD-4GY" userLabel="bar container">
                                                 <rect key="frame" x="0.0" y="600" width="600" height="300"/>
                                                 <subviews>
-                                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="r8V-JB-uAd" customClass="LineChartView" customModule="Charts">
+                                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="r8V-JB-uAd" customClass="BarChartView" customModule="Charts">
                                                         <rect key="frame" x="8" y="8" width="584" height="284"/>
                                                         <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                                     </view>
@@ -238,7 +238,7 @@
                     </view>
                     <navigationItem key="navigationItem" title="Analysis" id="NZr-Ll-eQV"/>
                     <connections>
-                        <outlet property="energyLineChart" destination="r8V-JB-uAd" id="A3I-0C-ENW"/>
+                        <outlet property="energyBarChart" destination="r8V-JB-uAd" id="gvM-uZ-6au"/>
                         <outlet property="keysPieChart" destination="sNQ-He-4Dy" id="1lg-6A-2gg"/>
                         <outlet property="scrollView" destination="39e-9t-au5" id="2xb-46-yLk"/>
                         <outlet property="valenceLineChart" destination="8po-IE-zp4" id="pjj-ae-cID"/>

--- a/spotifyMini/ViewControllers/Analysis/AnalysisViewController.swift
+++ b/spotifyMini/ViewControllers/Analysis/AnalysisViewController.swift
@@ -75,6 +75,8 @@ class AnalysisViewController : UIViewController {
     func setupBarChartForEnergy() {
         if let analysis = self.analysis {
             self.energyBarChart.data = self.barChartDataForEnergy(analysis)
+            self.energyBarChart.leftAxis.valueFormatter = NSNumberFormatter.formatterThatTrimsFloats()
+            self.energyBarChart.rightAxis.valueFormatter = NSNumberFormatter.formatterThatTrimsFloats()
         }
     }
 
@@ -97,10 +99,8 @@ class AnalysisViewController : UIViewController {
         lineDataSet.circleColors = colors ?? ChartColorTemplates.joyful()
         lineDataSet.setColor(UIColor.greenColor())
 
-        let formatter = NSNumberFormatter()
-        formatter.allowsFloats = false
-        formatter.numberStyle = .PercentStyle
-        lineDataSet.valueFormatter = formatter
+        lineDataSet.valueFormatter = NSNumberFormatter.formatterThatTrimsFloats()
+        lineDataSet.valueFormatter?.numberStyle = .PercentStyle
 
         return LineChartData(xVals: Analysis.keyTitles, dataSet: lineDataSet)
     }
@@ -120,9 +120,8 @@ class AnalysisViewController : UIViewController {
         let pieDataSet = PieChartDataSet(yVals: pieDataEntries, label: "")
         pieDataSet.axisDependency = .Left
         pieDataSet.colors = colors ?? ChartColorTemplates.pastel()
-        let formatter = NSNumberFormatter()
-        formatter.allowsFloats = false
-        pieDataSet.valueFormatter = formatter
+        pieDataSet.valueFormatter = NSNumberFormatter.formatterThatTrimsFloats()
+
         return PieChartData(xVals: Analysis.keyTitles, dataSet: pieDataSet)
     }
 
@@ -143,8 +142,9 @@ class AnalysisViewController : UIViewController {
         let dataSet = BarChartDataSet(yVals: dataEntries, label: "# of Tracks per Energy Level (0.0 - 1.0)")
         dataSet.axisDependency = .Left
         dataSet.colors = colors ?? ChartColorTemplates.joyful()
+        dataSet.valueFormatter = NSNumberFormatter.formatterThatTrimsFloats()
 
-        let bucketTitles = buckets.map { String($0) }
+        let bucketTitles = buckets.map { String(Int($0 * 10)) }
         return BarChartData(xVals: bucketTitles, dataSet: dataSet)
     }
 
@@ -166,5 +166,13 @@ class AnalysisViewController : UIViewController {
 
     func stopObservingAnalysisNotification() {
         NSNotificationCenter.defaultCenter().removeObserver(self, name: AnalysisFetchedTrackInfoNotification, object: self.analysis)
+    }
+}
+
+extension NSNumberFormatter {
+    class func formatterThatTrimsFloats() -> NSNumberFormatter {
+        let formatter = NSNumberFormatter()
+        formatter.allowsFloats = false
+        return formatter
     }
 }


### PR DESCRIPTION
With more than 100 tracks, the line chart with individual energy values was ugly and cumbersome to navigate. This changes it to a bar chart that tallies up all values within buckets (0.1, 0.2, 0.3, etc) 

Might be easier to understand if instead of 0.1, 0.2, the buckets were just 1, 2, 3, etc. Thoughts?
UPDATE: did that^ think it looks much better.
