### PR TITLE
addGenreToRealm

### DIFF
--- a/spotifyMini.xcodeproj/project.pbxproj
+++ b/spotifyMini.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		94BAC76211553E5068AFA487 /* Pods_spotifyMini.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E1500CA6C361146D1E72F80A /* Pods_spotifyMini.framework */; };
 		B805520E1CE6198800E20F24 /* AnalysisViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B805520D1CE6198800E20F24 /* AnalysisViewController.swift */; };
+		B80552171CEE4D2300E20F24 /* Genre.swift in Sources */ = {isa = PBXBuildFile; fileRef = B80552161CEE4D2300E20F24 /* Genre.swift */; };
 		B81F7F9C1CDA99E30092F13D /* ArtistSearchTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B81F7F9B1CDA99E30092F13D /* ArtistSearchTableViewController.swift */; };
 		B82462A41CE3C6AF009462F6 /* TrackAnalysis.swift in Sources */ = {isa = PBXBuildFile; fileRef = B82462A31CE3C6AF009462F6 /* TrackAnalysis.swift */; };
 		B84D372B1CDBB809006313C2 /* PopularTrackTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = B84D372A1CDBB809006313C2 /* PopularTrackTableViewCell.swift */; };
@@ -33,6 +34,7 @@
 		4F361AC5DD7EB886FAB24B84 /* Pods-spotifyMini.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-spotifyMini.release.xcconfig"; path = "Pods/Target Support Files/Pods-spotifyMini/Pods-spotifyMini.release.xcconfig"; sourceTree = "<group>"; };
 		57E3AF3B2F75B3AF547C2A49 /* Pods-spotifyMini.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-spotifyMini.debug.xcconfig"; path = "Pods/Target Support Files/Pods-spotifyMini/Pods-spotifyMini.debug.xcconfig"; sourceTree = "<group>"; };
 		B805520D1CE6198800E20F24 /* AnalysisViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = AnalysisViewController.swift; path = ViewControllers/Analysis/AnalysisViewController.swift; sourceTree = "<group>"; };
+		B80552161CEE4D2300E20F24 /* Genre.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Genre.swift; path = Models/Genre.swift; sourceTree = "<group>"; };
 		B81F7F9B1CDA99E30092F13D /* ArtistSearchTableViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = ArtistSearchTableViewController.swift; path = ViewControllers/Search/ArtistSearchTableViewController.swift; sourceTree = "<group>"; };
 		B82462A31CE3C6AF009462F6 /* TrackAnalysis.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = TrackAnalysis.swift; path = Models/TrackAnalysis.swift; sourceTree = "<group>"; };
 		B84D372A1CDBB809006313C2 /* PopularTrackTableViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = PopularTrackTableViewCell.swift; path = ViewControllers/Artist/PopularTrackTableViewCell.swift; sourceTree = "<group>"; };
@@ -103,6 +105,7 @@
 				B87193211CE21C1000D17885 /* Artist.swift */,
 				B82462A31CE3C6AF009462F6 /* TrackAnalysis.swift */,
 				E24CAE051CE5728700EDA744 /* Analysis.swift */,
+				B80552161CEE4D2300E20F24 /* Genre.swift */,
 			);
 			name = Models;
 			sourceTree = "<group>";
@@ -332,6 +335,7 @@
 				B82462A41CE3C6AF009462F6 /* TrackAnalysis.swift in Sources */,
 				E25EF2F21CEB6F8700BF062F /* GenreSelectTableViewController.swift in Sources */,
 				B84D372B1CDBB809006313C2 /* PopularTrackTableViewCell.swift in Sources */,
+				B80552171CEE4D2300E20F24 /* Genre.swift in Sources */,
 				B8A7E0CB1CDA4AB300E10028 /* AppDelegate.swift in Sources */,
 				B8AC3ACB1CDB804400914FAE /* ArtistViewController.swift in Sources */,
 				B87193221CE21C1000D17885 /* Artist.swift in Sources */,

--- a/spotifyMini/Models/Genre.swift
+++ b/spotifyMini/Models/Genre.swift
@@ -1,0 +1,19 @@
+//
+//  Genre.swift
+//  spotifyMini
+//
+//  Created by Tom O'Malley on 5/19/16.
+//  Copyright © 2016 intrepid. All rights reserved.
+//
+
+import Foundation
+import RealmSwift
+
+final class Genre : RealmSwift.Object {
+    dynamic var stringValue = ""
+
+    convenience init(string: String) {
+        self.init()
+        self.stringValue = string
+    }
+}

--- a/spotifyMini/Models/TrackAnalysis.swift
+++ b/spotifyMini/Models/TrackAnalysis.swift
@@ -33,6 +33,8 @@ final class TrackAnalysis : RealmSwift.Object, MappableObject {
         return mode == 0
     }
 
+    let genres = List<Genre>()
+
     // MARK: Questionably Useful
     dynamic var instrumentalness: Float = 0.0
     dynamic var speechiness: Float = 0.0

--- a/spotifyMini/ViewControllers/Analysis/AnalysisViewController.swift
+++ b/spotifyMini/ViewControllers/Analysis/AnalysisViewController.swift
@@ -13,7 +13,7 @@ import Charts
 class AnalysisViewController : UIViewController {
 
     let spotify = Spotify.manager
-    var genre: String?
+    var genre: Genre?
     var analysis: Analysis? {
         willSet {
             self.stopObservingAnalysisNotification()
@@ -36,12 +36,12 @@ class AnalysisViewController : UIViewController {
 
     func fetchRecommendedTracksAndSetUpCharts() {
         if let genre = self.genre {
-            self.title = genre.uppercaseString
-            self.spotify.fetchRecommendedTracks(forGenre: genre) { result in
+            self.title = genre.stringValue.uppercaseString
+            self.spotify.fetchRecommendedTracks(forGenre: genre.stringValue) { result in
                 if let error = result.error as? SpotifyError {
                     self.presentErrorAlert(error)
                 } else if let tracks = result.value {
-                    self.analysis = Analysis(tracks: tracks, name: genre)
+                    self.analysis = Analysis(tracks: tracks, genre: genre)
                     self.analysis?.fetchAnalyses()
                 }
             }
@@ -49,7 +49,7 @@ class AnalysisViewController : UIViewController {
             let charts = [self.keysPieChart, self.valenceLineChart, self.energyBarChart ]
             charts.forEach {
                 $0.descriptionText = ""
-                $0.noDataText = "Analyzing \(genre)..."
+                $0.noDataText = "Analyzing \(genre.stringValue)..."
                 $0.animate(yAxisDuration: 2.0, easingOption: ChartEasingOption.EaseInBounce)
                 $0.layer.cornerRadius = 8
             }
@@ -156,7 +156,7 @@ class AnalysisViewController : UIViewController {
                 let spotifyError = SpotifyError(error: error) {
                 self.presentErrorAlert(spotifyError)
             } else {
-                self.title = self.analysis?.name.uppercaseString
+                self.title = self.analysis?.genre.stringValue.uppercaseString
                 self.setupPieChartForMostFrequentSongKeys()
                 self.setupLineChartForAvgValenceByKey()
                 self.setupBarChartForEnergy()


### PR DESCRIPTION
- adds Genre class
- adds `var genres: List<Genre>` property to `TrackAnalysis`
- GenreSelectTVC refactored:
  - doesn't use string to populate tableview anymore, uses Genre objects 
  - loads genres from realm, then loads from Spotify as well. 
  - if it finds any new genres, it creates a new Genre, adds it to Realm, and reloads the tableview
  - on selection, passes Genre forward to AnalysisViewController
- AnalysisViewController doesn't use genre String, uses Genre object for Analysis creation.
- Analysis refactored: 
  - doesn't have a `name` property, instead has a `genre` property, of (you guessed it) type `Genre`
  - when fetching TrackAnalyses, first checks for every analyses matching it's genre.
  - when saving TrackAnalyses, associates it's genre with them
